### PR TITLE
New feature: Command dictionary

### DIFF
--- a/bot_commands.py
+++ b/bot_commands.py
@@ -582,6 +582,20 @@ class Command(object):
                 formatted=True,
                 code=False,
             )
+            if self.command_dict.is_not_empty():
+                command_dict_help = "Commands from command dictionary:\n"
+                for icom in self.command_dict:
+                    command_dict_help += f"\n- {icom}: {self.command_dict.get_help(icom)}"
+                await send_text_to_room(
+                    self.client,
+                    self.room.room_id,
+                    command_dict_help,
+                    markdown_convert=True,
+                    formatted=True,
+                    code=False,
+                    split=None,
+                )
+
             return
         else:
             response = f"Unknown help topic `{topic}`!"

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -33,7 +33,7 @@ SERVER_ERROR_MSG = "Bot encountered an error. Here is the stack trace: \n"
 class Command(object):
     """Use this class for your bot commands."""
 
-    def __init__(self, client, store, config, command, room, event):
+    def __init__(self, client, store, config, command_dict, command, room, event):
         """Set up bot commands.
 
         Arguments:
@@ -41,6 +41,7 @@ class Command(object):
             client (nio.AsyncClient): The client to communicate with Matrix
             store (Storage): Bot storage
             config (Config): Bot configuration parameters
+            command_dict (CommandDict): Command dictionary
             command (str): The command and arguments
             room (nio.rooms.MatrixRoom): The room the command was sent in
             event (nio.events.room_events.RoomMessageText): The event
@@ -50,6 +51,7 @@ class Command(object):
         self.client = client
         self.store = store
         self.config = config
+        self.command_dict = command_dict
         self.command = command
         self.room = room
         self.event = event
@@ -523,6 +525,15 @@ class Command(object):
                 markdown_convert=False,
                 formatted=True,
                 code=False,
+            )
+        # command from command dict
+        elif self.commandlower in self.command_dict:
+            await self._os_cmd(
+                cmd=self.command_dict.get_cmd(self.commandlower),
+                args=self.args,
+                markdown_convert=False,
+                formatted=True,
+                code=True,
             )
         else:
             await self._unknown_command()

--- a/callbacks.py
+++ b/callbacks.py
@@ -31,6 +31,7 @@ from nio import (
 )
 import logging
 import traceback
+from command_dict import CommandDict
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +48,12 @@ class Callbacks(object):
             store (Storage): Bot storage
             config (Config): Bot configuration parameters
 
+
         """
         self.client = client
         self.store = store
         self.config = config
+        self.command_dict = CommandDict(config.command_dict_filepath)
         self.command_prefix = config.command_prefix
 
     async def message(self, room, event):
@@ -95,7 +98,7 @@ class Callbacks(object):
             msg = msg[len(self.command_prefix):]
 
         command = Command(self.client, self.store,
-                          self.config, msg, room, event)
+                          self.config, self.command_dict, msg, room, event)
         await command.process()
 
     async def invite(self, room, event):

--- a/command_dict.py
+++ b/command_dict.py
@@ -43,6 +43,15 @@ class CommandDict:
     def __getitem__(self, item):
         return self.commands[item]
 
+    def __iter__(self):
+        return self.commands.__iter__()
+
+    def is_not_empty(self):
+        """Returns whether there are commands in the dictionary.
+
+        """
+        return len(self.commands) > 0
+
     def get_cmd(self, command):
         """Return the name of the executable associated with the given command,
         for the system to call.
@@ -62,5 +71,8 @@ class CommandDict:
             command (str): Name of the command in the command dictionary
 
         """
-        return self.commands[command]["help"]
+        if "help" in self.commands[command]:
+            return self.commands[command]["help"]
+        else:
+            return "No help defined for this command."
 

--- a/command_dict.py
+++ b/command_dict.py
@@ -1,0 +1,66 @@
+import sys
+import os
+import logging
+import yaml
+
+logger = logging.getLogger(__name__)
+
+class CommandDict:
+
+    def __init__(self, command_dict_filepath):
+        """Initialize command dictionary.
+
+        Arguments:
+        ---------
+            command_dict (str): Path to command dictionary.
+
+        """
+
+        self.command_dict = None
+        self.commands = {}
+
+        if command_dict_filepath:
+            try:
+                with open(command_dict_filepath) as fobj:
+                    logger.debug(f"Loading command dictionary at {command_dict_filepath}")
+                    self.command_dict = yaml.safe_load(fobj.read())
+
+                if "commands" in self.command_dict.keys():
+                    self.commands = self.command_dict["commands"]
+
+                if "paths" in self.command_dict.keys():
+                    os.environ["PATH"] = os.pathsep.join(self.command_dict["paths"]+[os.environ["PATH"]])
+                    logger.debug(f'Path modified. Now: {os.environ["PATH"]}')
+
+            except FileNotFoundError:
+                logger.error(f"File not found: {command_dict_filepath}")
+
+        return
+
+    def __contains__(self, command):
+        return command in self.commands.keys()
+
+    def __getitem__(self, item):
+        return self.commands[item]
+
+    def get_cmd(self, command):
+        """Return the name of the executable associated with the given command,
+        for the system to call.
+
+        Arguments:
+        ----------
+            command (str): Name of the command in the command dictionary
+
+        """
+        return self.commands[command]["cmd"]
+
+    def get_help(self,command):
+        """Return the help string of the given command.
+
+        Arguments:
+        ----------
+            command (str): Name of the command in the command dictionary
+
+        """
+        return self.commands[command]["help"]
+

--- a/commands.yaml.example
+++ b/commands.yaml.example
@@ -1,0 +1,29 @@
+# This is an example command dictionary configuration. Mind you, this is an
+# example script meant to convey the structure of this configuration, it will
+# probably not work as is on your terminal.
+
+# Paths that will be added to the runtime PATH variable. Add any paths of
+# executables called from your custom commands, the paths of which are not 
+# yet in the environment PATH variable.
+paths:
+    - /home/YOURUSER/.local/lib/matrix-eno-bot/eno/scripts
+    - /home/YOURUSER/.local/etc/matrix-eno-bot/bin
+ 
+# Definitions of custom commands.
+# The children of the "commands" key are the command names. These are the
+# commands that you want to add to your bot, and which you will invoke by name.
+# They in turn may have the following keys:
+#   cmd:  the executable, which the system will attempt to call and pass
+#         arguments to
+#   help: the help string for when you forget how use the command
+commands:
+    sshstart:
+      cmd: ssh_start
+      help: "Open SSH port, return external IP"
+    sshstop:
+      cmd: ssh_stop
+      help: "Close SSH port"
+    getip:
+      cmd: getextip
+      help: "Return external IP"
+

--- a/config.py
+++ b/config.py
@@ -73,6 +73,8 @@ class Config(object):
             ["storage", "database_filepath"], required=True)
         self.store_filepath = self._get_cfg(
             ["storage", "store_filepath"], required=True)
+        self.command_dict_filepath = self._get_cfg(
+            ["storage", "command_dict_filepath"], default=None)
 
         # Create the store folder if it doesn't exist
         if not os.path.isdir(self.store_filepath):

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -55,6 +55,8 @@ storage:
   # The path to a directory for internal bot storage
   # containing encryption keys, sync tokens, etc.
   store_filepath: "./store"
+  # The path to the command dictionary configuration file
+  # command_dict_filepath: "./commands.yaml"
 
 # Logging setup
 logging:


### PR DESCRIPTION
The introduced feature allows the user to define in a YAML file commands, their help strings and the paths which should be added to the runtime PATH environment variable in order to execute them. This allows users to extend their bot without having to modify the source files. This is positive because then the users can freely pull the latest updates from the git repository without needing to merge changes, which can be painful. Additionally, new commands and their help strings are very easy to add.

When the user runs the `help all` or `help commands` command, the commands and their help are included in the reply string, in the same format currently used by the `help.sh` script.